### PR TITLE
Pickle Fixes

### DIFF
--- a/display_controller/waveshare_epaper.py
+++ b/display_controller/waveshare_epaper.py
@@ -50,9 +50,7 @@ class Waveshare_ePaper(Display):
         )
 
         if not debug_mode:
-            # self.driver_module = importlib.import_module('.waveshare', package=f'{supported_models[model]["driver_module"]}')
-            # self.driver_module = importlib.import_module(f'waveshare.{supported_models[model]["driver_module"]}')
-            self.driver_module = importlib.import_module(f'display_controller.waveshare.{supported_models[model]["driver_module"]}')
+            # self.driver_module = importlib.import_module(f'display_controller.waveshare.{supported_models[model]["driver_module"]}')
             atexit.register(self.cleanup)
 
     def display_image(self, image, sleep_display=True):
@@ -87,4 +85,5 @@ class Waveshare_ePaper(Display):
             log.info('debug_mode = True, clean-up not needed.')
         else:
             log.info('Running clean-up function')
-            self.driver_module.epdconfig.module_exit(cleanup=True)
+            driver_module = importlib.import_module(f'display_controller.waveshare.{supported_models[model]["driver_module"]}')
+            driver_module.epdconfig.module_exit(cleanup=True)

--- a/display_controller/waveshare_epaper.py
+++ b/display_controller/waveshare_epaper.py
@@ -51,6 +51,7 @@ class Waveshare_ePaper(Display):
 
         if not debug_mode:
             # self.driver_module = importlib.import_module(f'display_controller.waveshare.{supported_models[model]["driver_module"]}')
+            self.driver_module_name = f'display_controller.waveshare.{supported_models[model]["driver_module"]}'
             atexit.register(self.cleanup)
 
     def display_image(self, image, sleep_display=True):
@@ -85,5 +86,5 @@ class Waveshare_ePaper(Display):
             log.info('debug_mode = True, clean-up not needed.')
         else:
             log.info('Running clean-up function')
-            driver_module = importlib.import_module(f'display_controller.waveshare.{supported_models[model]["driver_module"]}')
+            driver_module = importlib.import_module(self.driver_module_name)
             driver_module.epdconfig.module_exit(cleanup=True)

--- a/display_controller/waveshare_epaper.py
+++ b/display_controller/waveshare_epaper.py
@@ -62,7 +62,8 @@ class Waveshare_ePaper(Display):
             log.info('Pushing image to display...')
 
             log.info('Initializing screen...')
-            self.epd = self.driver_module.EPD()
+            driver_module = importlib.import_module(self.driver_module_name)
+            self.epd = driver_module.EPD()
             self.epd.init()
             self.epd.Clear()
 

--- a/forecast_api/accuweather.py
+++ b/forecast_api/accuweather.py
@@ -198,8 +198,8 @@ class AccuWeather(WeatherForecast):
 
             new_forecast = ForecastData(
                 forecast_datetime= datetime.strptime(forecast_date, '%Y-%m-%dT%H:%M:%S%z')
-                , current_temperature= response['Temperature'][str(self.unit_type.name).title()]['Value']
-                , feels_like_temperature= response['RealFeelTemperature'][str(self.unit_type.name).title()]['Value']
+                , current_temperature= response['Temperature'][str(self.unit_type).title()]['Value']
+                , feels_like_temperature= response['RealFeelTemperature'][str(self.unit_type).title()]['Value']
                 , weather_icon_raw= response['WeatherIcon']
                 , weather_icon= self._weather_icon_map[response['WeatherIcon']]
                 , weather_text= response['WeatherText']


### PR DESCRIPTION
To allow the display controller to be pickled, the WaveShare module is imported when functions are called, but is not persisted as part of the class. Additionally, the "cleanup" function is only needed when a keyboard interrupt happens, so this functionality was moved into the display_image function.